### PR TITLE
Fix a parallelization bug and add pause()/resume() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ var output = fs.createWriteStream('test.txt');
 lineStream.pipe(output);
 ```
 
+#Pausing
+
+A stream can be paused in order to do asynchronous processing.
+
+```javascript
+var stream = byline(fs.createReadStream('sample.txt'));
+stream.on('data', function (line) {
+  stream.pause();
+  doSomethingAsync(function (err) {
+    stream.resume();
+  });
+});
+```
+
 #Simple
 Unlike other modules (of which there are many), `byline` contains no:
 

--- a/lib/byline.js
+++ b/lib/byline.js
@@ -55,6 +55,9 @@ function LineStream() {
   this.writable = true;
   this.readable = true;
   this.buffer = '';
+  this.queue = [];
+  this.queueMax = 100;
+  this.isPaused = false;
 }
 util.inherits(LineStream, Stream);
 
@@ -70,15 +73,51 @@ LineStream.prototype.write = function(data, encoding) {
   }
 
   for (var i = 0; i < parts.length -1; i++) {
-    this.emit('data', parts[i]);
+    if (!this.isPaused) {
+      this.emit('data', parts[i]);
+    } else {
+      this.queue.push(parts[i]);
+    }
   }
 
   this.buffer = parts[parts.length - 1];
+
+  return this.queue.length <= this.queueMax;
 };
 
 LineStream.prototype.end = function() {
-  if (this.buffer.length > 0) {
-    this.emit('data', this.buffer);
+  if (!this.isPaused) {
+    if (this.buffer.length > 0) {
+      this.emit('data', this.buffer);
+      this.buffer = '';
+    }
+    this.emit('end');
+  } else {
+    if (this.buffer.length > 0) {
+      this.queue.push(this.buffer);
+      this.buffer = '';
+    }
+    this.queue.push(null);
   }
-  this.emit('end');
+};
+
+LineStream.prototype.pause = function() {
+  this.isPaused = true;
+};
+
+LineStream.prototype.resume = function() {
+  this.isPaused = false;
+  var line;
+  while (this.queue.length && !this.isPaused) {
+    line = this.queue.shift();
+    if (line !== null) {
+      this.emit('data', line);
+    } else {
+      // EOF
+      this.emit('end');
+    }
+  }
+  if (!this.queue.length) {
+    this.emit('drain');
+  }
 };


### PR DESCRIPTION
Sorry to combine these two commits into one pull request.

First commit is a simple bugfix: The library currently overwrites it's prototype in the constructor, which means that the self variable always points to the most recently created LineStream. If you try to use more than one LineStream at the same time, they would share a buffer and other weirdness would be happening.

The second commit adds pause and resume methods to the stream and adds documentation for these in the README.

Enjoy and thanks for a great little library. :+1:
