### PR TITLE
After pipe.(writeStream) , writeStream data is Only One Line

### DIFF
--- a/lib/byline.js
+++ b/lib/byline.js
@@ -70,7 +70,7 @@ function LineStream() {
     }
 
     for (var i = 0; i < parts.length -1; i++) {
-      self.emit('data', parts[i]);
+      self.emit('data', new Buffer(parts[i] + "\n"));
     }
 
     self.buffer = parts[parts.length - 1];


### PR DESCRIPTION
byline = require 'byline'
fs = require 'fs'

src = fs.createReadStream 'data/inputline.txt'
dest = fs.createWriteStream 'data/outputline.txt'

src = byline.createStream src
# 
# not buffer !!
# src.pipe(dest)
# => dest contents is only one line !!
# 

src.on 'data', (data)->
  console.log data.toString()

src.pipe dest 
