### PR TITLE
Fix: Line buffer was not being exhausted.

### DIFF
--- a/lib/byline.js
+++ b/lib/byline.js
@@ -85,7 +85,7 @@ LineStream.prototype._transform = function(chunk, encoding, done) {
   
   this._lineBuffer = this._lineBuffer.concat(lines);
   
-  while (this._lineBuffer.length > 1) {
+  while (this._lineBuffer.length > 0) {
     var line = this._lineBuffer.shift();
     if (!this.push(line)) {
       break;


### PR DESCRIPTION
That seemed to fixed my issues with duplicate lines. Buffer was never completely emptied, so after the first line they were all duplicates.
