### PR TITLE
Correct reencoding

### DIFF
--- a/lib/byline.js
+++ b/lib/byline.js
@@ -121,9 +121,9 @@ LineStream.prototype._flush = function(done) {
 };
 
 // see Readable::push
-LineStream.prototype._reencode = function(chunk, encoding) {
-  if (encoding !== this._readableState.encoding) {
-    chunk = new Buffer(chunk, encoding);
+LineStream.prototype._reencode = function(chunk) {
+  if (this._readableState.encoding) {
+    chunk = new Buffer(chunk).toString(this._readableState.encoding);
   }
   return chunk;
 };


### PR DESCRIPTION
I believe, this is correct handling of _readableState.encoding.
Stream should not sometimes push buffers and sometimes strings. Let him push strings only.
`toString` conversion here isn't necessary - underlying stream implementation would do it anyway. But I added it for clarity.
