### PR TITLE
Added skipEmptyLines option

### DIFF
--- a/lib/byline.js
+++ b/lib/byline.js
@@ -65,6 +65,11 @@ function LineStream(options) {
   // which re-concatanates the lines, just without newlines.
   this._readableState.objectMode = true;
   this._lineBuffer = [];
+  options = options || {};
+  this._skipEmptyLines = true;
+  if (options.skipEmptyLines !== undefined && options.skipEmptyLines !== null) {
+      this._skipEmptyLines = options.skipEmptyLines;
+  }
 }
 util.inherits(LineStream, stream.Transform);
 
@@ -73,7 +78,7 @@ LineStream.prototype._transform = function(chunk, encoding, done) {
   encoding = encoding || 'utf8';
   
   if (Buffer.isBuffer(chunk)) {
-    if (encoding == 'buffer') {
+    if (encoding === 'buffer') {
       chunk = chunk.toString(); // utf8
       encoding = 'utf8';
     }
@@ -95,8 +100,14 @@ LineStream.prototype._transform = function(chunk, encoding, done) {
   // always buffer the last (possibly partial) line
   while (this._lineBuffer.length > 1) {
     var line = this._lineBuffer.shift();
-    // skip empty lines
-    if (line.length > 0 ) {
+    if (this._skipEmptyLines) {
+      // skip empty lines
+      if (line.length > 0 ) {
+        if (!this.push(this._reencode(line))) {
+          break;
+        }
+      }
+    } else {
       if (!this.push(this._reencode(line))) {
         break;
       }
@@ -110,8 +121,14 @@ LineStream.prototype._flush = function(done) {
   // flush all buffered lines
   while (this._lineBuffer.length > 0) {
     var line = this._lineBuffer.shift();
-    // skip empty lines
-    if (line.length > 0 ) {
+    if (this._skipEmptyLines) {
+      // skip empty lines
+      if (line.length > 0 ) {
+        if (!this.push(this._reencode(line))) {
+          break;
+        }
+      }
+    } else {
       if (!this.push(this._reencode(line))) {
         break;
       }

--- a/test/tests.js
+++ b/test/tests.js
@@ -43,6 +43,24 @@ describe('byline', function() {
       done();
     });
   });
+
+  it('should do not ignore empty lines', function(done) {
+    var input = fs.createReadStream('test/empty.txt');
+    var lineStream = byline(fs.createReadStream('test/empty.txt'), {
+        skipEmptyLines: false,
+        encoding: 'utf8'
+    });
+    
+    var lines1 = [];
+    lineStream.on('data', function(line) {
+      lines1.push(line);
+    });    
+    lineStream.on('end', function() {
+      var lines2 = fs.readFileSync('test/empty.txt', 'utf8').split(/\r\n|\r|\n/g);
+      assert.deepEqual(lines2, lines1);
+      done();
+    });
+  });
     
    it('should read a large file', function(done) {
     var input = fs.createReadStream('test/rfc.txt');


### PR DESCRIPTION
In some case (i.e. source code parsing) it is useful do not skip the empty lines to preserve the original line numbers.
