### PR TITLE
fixing thrown exception when providing deprecated encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .DS_Store
+.idea
+coverage.html
+node_modules

--- a/lib/byline.js
+++ b/lib/byline.js
@@ -133,7 +133,7 @@ LineStream.prototype._flush = function(done) {
 // see Readable::push
 LineStream.prototype._reencode = function(line, chunkEncoding) {
   if (this.encoding && this.encoding != chunkEncoding) {
-    return new Buffer(line, chunkEncoding).toString(encoding);
+    return new Buffer(line, chunkEncoding).toString(this.encoding);
   }
   else if (this.encoding) {
     // this should be the most common case, i.e. we're using an encoded source stream

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-      "test": "mocha -R spec",
-      "test-cov": "mocha -r blanket -R html-cov > coverage.html"
+    "test": "mocha -R spec",
+    "test-cov": "mocha -r blanket -R html-cov > coverage.html"
   },
   "main": "./lib",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,5 +15,22 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "main": "./lib"
+  "scripts": {
+      "test": "mocha -R spec",
+      "test-cov": "mocha -r blanket -R html-cov > coverage.html"
+  },
+  "main": "./lib",
+  "devDependencies": {
+    "mocha": "^1.18.2",
+    "blanket": "^1.1.6"
+  },
+  "config": {
+    "blanket": {
+      "pattern": "lib",
+      "data-cover-never": [
+        "node_modules",
+        "test"
+      ]
+    }
+  }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -124,7 +124,15 @@ describe('byline', function() {
     });
   });
 
-  it('should handle encoings like fs', function(done) {
+  describe('when the source stream encoding is set to a deprecated encoding', function () {
+    it('should not throw an exception', function () {
+      assert.doesNotThrow(function () {
+        byline(fs.createReadStream('test/rfc.txt', { encoding: 'utf-8' }));
+      });
+    });
+  });
+
+  it('should handle encodings like fs', function(done) {
     areStreamsEqualTypes(null, function() {
       areStreamsEqualTypes({ encoding: 'utf8' }, function() {
         done();


### PR DESCRIPTION
I haven't been able to find the encoding 'utf-8' anywhere in the documentation of node, but it seems like some of their methods (such as this one you are using, `Buffer.toString()`) do accept that as an encoding without throwing an exception. I have changed my code to use the encoding 'utf8' instead of 'utf-8', but all that does is prevent me from traveling this code path that had a bug in it.

So here's a fix for the bug, along with a test that causes that code path to be travelled. I also added some npm scripts so you can just do `npm test` to run your tests, and `npm run test-cov` to get a coverage report on the library.

For the record, the exception that was being thrown by node-byline was `ReferenceError: encoding is not defined`