### PR TITLE
Don't bundle tests in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "node": ">=0.10.0"
   },
   "main": "./lib/byline.js",
+  "files": {
+    "lib"
+  },
   "devDependencies": {
     "mocha": "~2.1.0",
     "request": "~2.27.0"


### PR DESCRIPTION
`byline` is huge, and unnecessarily so.

https://docs.npmjs.com/files/package.json#files

```
byline@4.2.1 $  du -h -d 1
148K    ./.idea
8.0K    ./lib
1.3M    ./test
1.5M    .
```

The only thing we want is `lib`, so this change will prevent deploying `.idea` and `test` to npm.