### PR TITLE
Fix deprecation warnings about Buffer api usage

### DIFF
--- a/lib/byline.js
+++ b/lib/byline.js
@@ -140,16 +140,26 @@ LineStream.prototype._flush = function(done) {
   this._pushBuffer(this._chunkEncoding, 0, done);
 };
 
+LineStream.prototype._toBuffer = function(string, encoding) {
+  if (typeof Buffer.from === 'function') {
+    return Buffer.from(string, encoding);
+  } else {
+    // this was deprecated in node v5 in favor
+    // of Buffer.from(string, encoding)
+    return new Buffer(string, encoding);
+  }
+}
+
 // see Readable::push
 LineStream.prototype._reencode = function(line, chunkEncoding) {
   if (this.encoding && this.encoding != chunkEncoding) {
-    return new Buffer(line, chunkEncoding).toString(this.encoding);
+    return this._toBuffer(line, chunkEncoding).toString(this.encoding);
   }
   else if (this.encoding) {
     // this should be the most common case, i.e. we're using an encoded source stream
     return line;
   }
   else {
-    return new Buffer(line, chunkEncoding);
+    return this._toBuffer(line, chunkEncoding);
   }
 };


### PR DESCRIPTION
@jahewson this is a simple PR to fix the current warnings about how the node `Buffer` api is being currently used into this library. This will also close https://github.com/jahewson/node-byline/issues/49

Can you please take a look and it possible release a patch version with this changes? All the tests are still passing also!